### PR TITLE
Fixed a `NameError: name 'mosek' is not defined` 

### DIFF
--- a/ncpol2sdpa/mosek_utils.py
+++ b/ncpol2sdpa/mosek_utils.py
@@ -64,6 +64,7 @@ def solve_with_mosek(sdpRelaxation, solverparameters=None):
     task = convert_to_mosek(sdpRelaxation)
     if solverparameters is not None:
         for par, val in solverparameters.items():
+            import mosek
             try:
                 mskpar = eval('mosek.iparam.' + par)
                 task.putintparam(mskpar, val)


### PR DESCRIPTION
in the line `mskpar = eval('mosek.iparam.' + par)` by importing mosek
